### PR TITLE
Outline: Fastq activity

### DIFF
--- a/workshop_materials/fastq-activity-notes.md
+++ b/workshop_materials/fastq-activity-notes.md
@@ -49,6 +49,12 @@ curl -o "${FASTQ_DEST}/${FASTQ_FILE_R1}" ${FASTQ_URL}/${FASTQ_FILE_R1}
 curl -o "${FASTQ_DEST}/${FASTQ_FILE_R2}" ${FASTQ_URL}/${FASTQ_FILE_R2}
 
 
+# We can do any of these with `if`, for example:
+if [ ! -f ${FASTQ_DEST}/${FASTQ_FILE_R1} ]; then
+  curl -o "${FASTQ_DEST}/${FASTQ_FILE_R1}" ${FASTQ_URL}/${FASTQ_FILE_R1}
+fi  
+  
+
 # Use a for-loop:
 for FASTQ in ${FASTQ_FILE_R1} ${FASTQ_FILE_R2}; do
   # pick an option here:


### PR DESCRIPTION
This PR sketches out part of #11, specifically the fastq file activity where we want them to write a shell script that uses `curl` to obtain a zipped fastq, unzip it, and do some _light!_ exploration.

Notes/discussion items

+ I found a probably-good-enough fastq that was cancer related and has the right size we are going for: Big enough to be a problem for git, but not big enough to be a burden for their computers 
+ What should the name of the directory where they move the fastq file into be?
+ Where should this script be, and are we also having them make that directory?
+ In the sketched out script in the notes here, I have two options for how we can go about moving the file. Any feedback?
+ Any other small exploration steps they could add into the script? I'll note I am not particularly interested in doing any math in bash (eg dividing by 4 to get number of reads).

We will likely also do some interactive exploration with `head` so they can see that command in action, but it wouldn't make sense to put in the script. 