### PR TITLE
Add .gitignore to this repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-**/.Rproj.user
-**/.Rhistory
-**/.RData
-**/.Ruserdata
-**/.DS_Store
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata
+.DS_Store


### PR DESCRIPTION
This PR adds a `.gitignore` file to _this_ repo. Not related to the `.gitignore` trainees will create. Rather, there are too many `.Rhistory` files in my life during development. This `.gitignore` recursively ignores the usual suspects.