### PR TITLE
Windows setup typos and clarifications

### DIFF
--- a/docs/setup_instructions/windows_installation_instructions.md
+++ b/docs/setup_instructions/windows_installation_instructions.md
@@ -25,7 +25,7 @@ title: Windows Installation Instructions
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 
-> Please be aware this setup process will take 1-2 hours to complete! 
+> Please be aware this setup process may take 1-2 hours to complete! 
 
 ## Windows Subsystem for Linux (WSL)
 


### PR DESCRIPTION
This PR addresses a couple typos and clarifies certain aspects of the RStudio installation process for the Windows setup. I also fix some of the relative links whose headers had changed but whose links didn't previously get updated. They should all be working now. 