### PR TITLE
Add draft schedule for October 2023

### DIFF
--- a/docs/workshop-schedule.md
+++ b/docs/workshop-schedule.md
@@ -3,28 +3,40 @@ title: Workshop Schedule
 nav_title: Schedule
 ---
 
-⚠️ **Please note:** The schedule below is from a past Data Lab Reproducible Research Practices Workshop that took place in June 2022.
-It will be modified for the October 2023 workshop.
-
-This schedule is an example of what participants can expect. 
-Each topic is linked to a Google Slides document with the content we presented in June.
-
-| Time | Topic |
-|------|---------|
-| 9:00 - 10:15 am  | [Welcome](https://docs.google.com/presentation/d/1GgqWl6las6ekQtKLmPzJ8UD_cftIbJjDTS2gJpStcMQ/edit?usp=sharing) <br> [Why does reproducibility matter?](https://docs.google.com/presentation/d/1qfulAR4jD0KS7NfrLHpwT6SWl-7APBmqNnAwGpXX5oo/edit?usp=sharing) |
-| 10:15 - 10:45 am | [Project organization](https://docs.google.com/presentation/d/1ncqxXlC0-PGEK-yE7S-nDYnMPhrOUPbI95EJy283wCs/edit?usp=sharing) |
-| 10:45 - 11:00 am | Coffee break | 
-| 11:00 - 11:30 am | [Introduction to UNIX and the command line](https://docs.google.com/presentation/d/1WPXkItJZEUXMY20cLrdMXHiBC2PyunR14RUSDg4nfIc/edit?usp=sharing) <br> [_Resource_: UNIX Reference](resources/unix_reference.html) <br> [_Resource_: UNIX Cheatsheet (pdf)](resources/unix_quick_reference.pdf) |
-| 11:30 - 12:00 pm | [Introduction to Git; Forking and cloning a repository](https://docs.google.com/presentation/d/1eiGZA4PYBKJx5HDCo3UDOAB7q415gg96TehxilCHwlA/edit?usp=sharing) |
-| 12:00 - 1:00 pm  | Lunch |
-| 1:00 - 1:45 pm   | [Shell scripting](https://docs.google.com/presentation/d/1SDUyYVNgvDDRodVqmDQPVQ5wnjQesWfBTg0EAcdbcSo/edit?usp=sharing) |
-| 1:45 - 2:15 pm   | [The git stage/commit/push workflow and `.gitignore` files](https://docs.google.com/presentation/d/1_YckNhAkp_82PKR6PGS5SdaKDgoueYVTXaPi5pQV9ik/edit?usp=sharing) |
-| 2:15 - 2:30 pm   | Coffee break |
-| 2:30 - 3:15 pm   | [Organizing code in scripts and notebooks](https://docs.google.com/presentation/d/1AJr6uQhwLnZfis1wNc_e2XY4XSMEuVscIfAsVgnM5Bk/edit?usp=sharing) |
-| 3:15 - 3:45 pm   | [Managing packages and environments](https://docs.google.com/presentation/d/1GCbu2F6LeEPOu5DzDsTgwu1__9YDVydvPo911fBG1i0/edit?usp=sharing) |
-| 3:45 - 4:15 pm | [Working with branches in Git](https://docs.google.com/presentation/d/1s7BSHgTSDuXIzI1ROS-JSneB6NXfQVWOec6lhc8eIWA/edit?usp=sharing) |
-| 4:15 - 5:00 pm   | Discuss your project(s) with Data Lab members |
+The schedule below is a tentative schedule for the October 2023 workshop.
+Times are subject to change, but the overall content should stay the same.
 
 
+## Day 1: 2 - 5 pm in Woodlands A&B
 
-A single pdf with all slides can be downloaded here: <br> [Reproducibility Workshop Slides (pdf)](resources/2022-06-10_reproducibility-workshop-slides.pdf)
+| Time | Topic | Location |
+|------|---------|---------|
+| 1:45    | _Participants arrive and check in_ | Woodlands A&B |
+| 2:00 pm | Welcome and introductions | Woodlands A&B |
+|         | Why does reproducibility matter? | Woodlands A&B |
+| 2:45 pm | Project organization | Woodlands A&B |
+| 3:15 pm | _Coffee break_ | Woodlands A&B |
+| 3:30 pm | Strategies for data sharing | Woodlands A&B |
+| 4:00 pm | Introduction to UNIX and the command line | Woodlands A&B |
+|         | Introduction to UNIX and the command line | Woodlands A&B |
+|         | [_Resource_: UNIX Reference](resources/unix_reference.html) ||
+|         | [_Resource_: UNIX Cheatsheet (pdf)](resources/unix_quick_reference.pdf) ||
+| 4:30 pm |  Introduction to Git; Forking and cloning a repository | Woodlands A&B |
+6pm 	Group dinner 	Everyone who chooses to attend 	Harper's Garden (31 S 18th St, Philadelphia, PA 19103)
+| 5:00 pm |  _Adjourn_ | |
+| 5:45pm  | _Optional_ Meet in the hotel lobby to walk to dinner | The Inn at Penn Lobby |
+| 6:00 pm | _Optional dinner_ at [Harper's Garden](https://www.harpersgardenphilly.com/) | 31 S 18th St, Philadelphia PA |
+
+## Day 2: 9 am - 2 pm in Conference room 603
+
+| Time | Topic | Location |
+|------|---------|---------|
+| 8:45 am  | _Participants arrive and have breakfast_ |  Conference room 603 |
+| 9:00 am  | Shell scripting |  Conference room 603 |
+| 9:45 am  | The git stage/commit/push workflow |  Conference room 603 |
+| 10:30 am | _Coffee break_ |  Conference room 603 |
+| 10:45 am | Organizing code in scripts and notebooks |  Conference room 603 |
+| 11:30 am | Managing packages and environments |  Conference room 603 |
+| 12:15 pm | _Lunch_ |  Conference room 603 |
+| 1:15 pm | Working with branches in Git |  Conference room 603 |
+| 2:00 pm | _Adjourn_ |  |

--- a/docs/workshop-schedule.md
+++ b/docs/workshop-schedule.md
@@ -18,11 +18,9 @@ Times are subject to change, but the overall content should stay the same.
 | 3:15 pm | _Coffee break_ | Woodlands A&B |
 | 3:30 pm | Strategies for data sharing | Woodlands A&B |
 | 4:00 pm | Introduction to UNIX and the command line | Woodlands A&B |
-|         | Introduction to UNIX and the command line | Woodlands A&B |
 |         | [_Resource_: UNIX Reference](resources/unix_reference.html) ||
 |         | [_Resource_: UNIX Cheatsheet (pdf)](resources/unix_quick_reference.pdf) ||
 | 4:30 pm |  Introduction to Git; Forking and cloning a repository | Woodlands A&B |
-6pm 	Group dinner 	Everyone who chooses to attend 	Harper's Garden (31 S 18th St, Philadelphia, PA 19103)
 | 5:00 pm |  _Adjourn_ | |
 | 5:45pm  | _Optional_ Meet in the hotel lobby to walk to dinner | The Inn at Penn Lobby |
 | 6:00 pm | _Optional dinner_ at [Harper's Garden](https://www.harpersgardenphilly.com/) | 31 S 18th St, Philadelphia PA |


### PR DESCRIPTION
Closes #121 

This PR adds the draft schedule. I have placed the NIH data sharing (#117) after day 1's coffee break so it piggy-backs on project organization, but this could also be subject to change! Given that addition, it didn't look like there was much time to do include a slot for "discuss your project with data lab members," but on the flip side we will have met a lot of the attendees already at YI so some of those chats may have already happened.