### PR TITLE
Add sharing section

### DIFF
--- a/docs/reproducibility_resources.md
+++ b/docs/reproducibility_resources.md
@@ -4,29 +4,23 @@ nav_title: Resources
 ---
 
 This list provides some links to resources on reproducibility topics that may be useful as you develop you reproducible research skills and practices.
- 
-Please note, this is not an exhaustive list. 
-It includes multiple types of resources for varying levels of experience, so we would not necessarily recommend every resource here for everyone. 
-Resources are listed by topic and in alphabetical order, not in order of recommendation. 
 
-<!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+Please note, this is not an exhaustive list.
+It includes multiple types of resources for varying levels of experience, so we would not necessarily recommend every resource here for everyone.
+Resources are listed by topic and in alphabetical order, not in order of recommendation.
 
-### Table of Contents
+**Table of contents**
 
-- [Comprehensive Resources](#comprehensive-resources)
-- [Git](#git)
-- [Project Organization](#project-organization) 
-- [Shell](#shell)
-- [UNIX](#unix)
+* TOC goes here
+{:toc}
 
 ## Comprehensive Resources
 
 + [Bioinformatics Data Skills - Vince Buffalo](https://www.oreilly.com/library/view/bioinformatics-data-skills/9781449367480/)
 + [Collections on Reproducibility - _Nature_](https://www.nature.com/collections/prbfkwmwvz)
-+ [Good Enough Practices in Scientific Computing - _PLOS Computational Biology_](https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1005510) 
++ [Good Enough Practices in Scientific Computing - _PLOS Computational Biology_](https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1005510)
 + [Guide for Reproducible Research - The Turing Way](https://the-turing-way.netlify.app/reproducible-research/reproducible-research.html)
-+ [Introduction to Reproducibility in Cancer Informatics course - Informatics Technology for Cancer Research (ITCR)](https://jhudatascience.org/Reproducibility_in_Cancer_Informatics/introduction.html) 
++ [Introduction to Reproducibility in Cancer Informatics course - Informatics Technology for Cancer Research (ITCR)](https://jhudatascience.org/Reproducibility_in_Cancer_Informatics/introduction.html)
 	+ [References list](https://jhudatascience.org/Reproducibility_in_Cancer_Informatics/references.html)
 + [Advanced Reproducibility in Cancer Informatics course - ITCR](https://jhudatascience.org/Adv_Reproducibility_in_Cancer_Informatics/introduction.html)
 + [Learning Bioinformatics at Home - Harvard Informatics Group](https://github.com/harvardinformatics/learning-bioinformatics-at-home)
@@ -34,10 +28,10 @@ Resources are listed by topic and in alphabetical order, not in order of recomme
 + [Reproducibility Standards for Machine Learning in the Life Sciences - nature](https://www.nature.com/articles/s41592-021-01256-7)
 + [Ten Simple Rules for Quick and Dirty Scientific Programming - _PLOS Computational Biology_](https://doi.org/10.1371/journal.pcbi.1008549)
 + [Ten Simple Rules for Reproducible Computational Research - _PLOS Computational Biology_](https://doi.org/10.1371/journal.pcbi.1003285)
-+ [Toronto Data Workshop - Rohan Alexander](https://rohanalexander.com/toronto_data_workshop.html) 
++ [Toronto Data Workshop - Rohan Alexander](https://rohanalexander.com/toronto_data_workshop.html)
 + [Toronto Workshop on Reproducibility - Rohan Alexander](https://rohanalexander.com/reproducibility.html)
 
-## Git 
+## Git
 
 + [Happy Git and GitHub for the UseR](https://happygitwithr.com/)
 + [Ten Simple Rules for Taking Advantage of Git and GitHub - _PLOS Computational Biology_](https://doi.org/10.1371/journal.pcbi.1004947)
@@ -47,9 +41,24 @@ Resources are listed by topic and in alphabetical order, not in order of recomme
 ## Project Organization
 
 + [Project Organization for Genomics - The Carpentries](https://datacarpentry.org/organization-genomics/)
-+ [protocols.io](https://www.protocols.io/)
 + [Ten Simple Rules for Writing Dockerfiles for Reproducible Data Science - _PLOS Computational Biology_](https://doi.org/10.1371/journal.pcbi.1008316)
 + [Ten Simple Rules for Writing and Sharing Computational Analyses in Jupyter Notebooks - _PLOS Computational Biology_](https://doi.org/10.1371/journal.pcbi.1007007)
+
+## Data, Materials, and Protocols Sharing
+### Resources for sharing
+
++ [DMPTool](https://dmptool.org/)
++ [Open Science Framework](https://osf.io/)
++ [protocols.io](https://www.protocols.io/)
+
+### Repositories for sharing
+
++ [Addgene](https://www.addgene.org/)
++ [Antibody Registry](https://www.antibodyregistry.org/)
++ [Jackson Labs](https://www.jax.org/)
++ [Mutant Mouse Resurce and Research Centers](https://www.mmrrc.org/)
++ [Repositories for sharing scientific data](https://sharing.nih.gov/data-management-and-sharing-policy/sharing-scientific-data/repositories-for-sharing-scientific-data)
++ [Zenodo](https://zenodo.org/)
 
 ## Shell
 
@@ -60,4 +69,4 @@ Resources are listed by topic and in alphabetical order, not in order of recomme
 
 + [Organizing with UNIX - Rafael Irizarry](https://rafalab.github.io/dsbook/unix.html)
 + [UNIX Bootcamp](https://github.com/griffithlab/rnaseq_tutorial/wiki/Unix-Bootcamp)
-+ [UNIX Tutorial for Beginners](http://www.ee.surrey.ac.uk/Teaching/Unix/) 
++ [UNIX Tutorial for Beginners](http://www.ee.surrey.ac.uk/Teaching/Unix/)

--- a/docs/reproducibility_resources.md
+++ b/docs/reproducibility_resources.md
@@ -28,8 +28,8 @@ Resources are listed by topic and in alphabetical order, not in order of recomme
 + [Reproducibility Standards for Machine Learning in the Life Sciences - Heil *et al.* (2021)](https://doi.org/10.1038/s41592-021-01256-7)
 + [Ten Simple Rules for Quick and Dirty Scientific Programming - Balaban *et al.* (2021)](https://doi.org/10.1371/journal.pcbi.1008549)
 + [Ten Simple Rules for Reproducible Computational Research - Sanvde *et al.* (2013)](https://doi.org/10.1371/journal.pcbi.1003285)
-+ [Toronto Data Workshop - Rohan Alexander](https://rohanalexander.com/toronto_data_workshop.html)
-+ [Toronto Workshop on Reproducibility - Rohan Alexander](https://rohanalexander.com/reproducibility.html)
++ [Toronto Data Workshop - Rohan Alexander](https://rohanalexander.com/events-tdw.html)
++ [Toronto Workshop on Reproducibility - Rohan Alexander](https://rohanalexander.com/events-reproducibility.html)
 
 ## Git
 

--- a/docs/reproducibility_resources.md
+++ b/docs/reproducibility_resources.md
@@ -17,32 +17,32 @@ Resources are listed by topic and in alphabetical order, not in order of recomme
 ## Comprehensive Resources
 
 + [Bioinformatics Data Skills - Vince Buffalo](https://www.oreilly.com/library/view/bioinformatics-data-skills/9781449367480/)
-+ [Collections on Reproducibility - _Nature_](https://www.nature.com/collections/prbfkwmwvz)
-+ [Good Enough Practices in Scientific Computing - _PLOS Computational Biology_](https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1005510)
++ [Collections on Reproducibility: Challenges in irreproducible research - _Nature_](https://www.nature.com/collections/prbfkwmwvz)
++ [Good Enough Practices in Scientific Computing - Wilson *et al.* (2017)](https://doi.org/10.1371/journal.pcbi.1005510)
 + [Guide for Reproducible Research - The Turing Way](https://the-turing-way.netlify.app/reproducible-research/reproducible-research.html)
 + [Introduction to Reproducibility in Cancer Informatics course - Informatics Technology for Cancer Research (ITCR)](https://jhudatascience.org/Reproducibility_in_Cancer_Informatics/introduction.html)
 	+ [References list](https://jhudatascience.org/Reproducibility_in_Cancer_Informatics/references.html)
 + [Advanced Reproducibility in Cancer Informatics course - ITCR](https://jhudatascience.org/Adv_Reproducibility_in_Cancer_Informatics/introduction.html)
 + [Learning Bioinformatics at Home - Harvard Informatics Group](https://github.com/harvardinformatics/learning-bioinformatics-at-home)
 + [Reproducibility 4 Everyone](https://www.repro4everyone.org/)
-+ [Reproducibility Standards for Machine Learning in the Life Sciences - nature](https://www.nature.com/articles/s41592-021-01256-7)
-+ [Ten Simple Rules for Quick and Dirty Scientific Programming - _PLOS Computational Biology_](https://doi.org/10.1371/journal.pcbi.1008549)
-+ [Ten Simple Rules for Reproducible Computational Research - _PLOS Computational Biology_](https://doi.org/10.1371/journal.pcbi.1003285)
++ [Reproducibility Standards for Machine Learning in the Life Sciences - Heil *et al.* (2021)](https://doi.org/10.1038/s41592-021-01256-7)
++ [Ten Simple Rules for Quick and Dirty Scientific Programming - Balaban *et al.* (2021)](https://doi.org/10.1371/journal.pcbi.1008549)
++ [Ten Simple Rules for Reproducible Computational Research - Sanvde *et al.* (2013)](https://doi.org/10.1371/journal.pcbi.1003285)
 + [Toronto Data Workshop - Rohan Alexander](https://rohanalexander.com/toronto_data_workshop.html)
 + [Toronto Workshop on Reproducibility - Rohan Alexander](https://rohanalexander.com/reproducibility.html)
 
 ## Git
 
 + [Happy Git and GitHub for the UseR](https://happygitwithr.com/)
-+ [Ten Simple Rules for Taking Advantage of Git and GitHub - _PLOS Computational Biology_](https://doi.org/10.1371/journal.pcbi.1004947)
++ [Ten Simple Rules for Taking Advantage of Git and GitHub - Perez-Riverol *et al.* (2016)](https://doi.org/10.1371/journal.pcbi.1004947)
 + [Version control with Git - The Carpentries](https://swcarpentry.github.io/git-novice/)
 + [New to Git - Gitkraken](https://support.gitkraken.com/start-here/guide/)
 
 ## Project Organization
 
 + [Project Organization for Genomics - The Carpentries](https://datacarpentry.org/organization-genomics/)
-+ [Ten Simple Rules for Writing Dockerfiles for Reproducible Data Science - _PLOS Computational Biology_](https://doi.org/10.1371/journal.pcbi.1008316)
-+ [Ten Simple Rules for Writing and Sharing Computational Analyses in Jupyter Notebooks - _PLOS Computational Biology_](https://doi.org/10.1371/journal.pcbi.1007007)
++ [Ten Simple Rules for Writing Dockerfiles for Reproducible Data Science - Nüst *et al.* (2020)](https://doi.org/10.1371/journal.pcbi.1008316)
++ [Ten Simple Rules for Writing and Sharing Computational Analyses in Jupyter Notebooks - Rule *et al.* (2019)](https://doi.org/10.1371/journal.pcbi.1007007)
 
 ## Data, Materials, and Protocols Sharing
 ### Resources for sharing

--- a/docs/reproducibility_resources.md
+++ b/docs/reproducibility_resources.md
@@ -57,7 +57,7 @@ Resources are listed by topic and in alphabetical order, not in order of recomme
 + [Antibody Registry](https://www.antibodyregistry.org/)
 + [Jackson Labs](https://www.jax.org/)
 + [Mutant Mouse Resurce and Research Centers](https://www.mmrrc.org/)
-+ [Repositories for sharing scientific data](https://sharing.nih.gov/data-management-and-sharing-policy/sharing-scientific-data/repositories-for-sharing-scientific-data)
++ [NIH-supported repositories for sharing scientific data](https://sharing.nih.gov/data-management-and-sharing-policy/sharing-scientific-data/repositories-for-sharing-scientific-data)
 + [Zenodo](https://zenodo.org/)
 
 ## Shell


### PR DESCRIPTION
Closes #127 

A couple changes here on our resources page:

1. Removed `doctoc` to let jekyll handle it
2. I added a section for resource sharing. I put several links here also inspired by some of ALSF's recommended repositories, but it's possibly overkill! I'm 100% fine with any suggestions to lessen links here; I figured it was better to file a PR with more, and pare it down from there. Of course, let me know also any additional links that would be good to include (I'll note I intentionally didn't include NIH or ALSF guidelines explicitly - more general resources that just have some incidental NIH overlap).