### PR TITLE
Add review demo activity

### DIFF
--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -5,6 +5,7 @@ Addgene
 al
 ALSF
 AnnData
+assignees
 authenticator
 Authy
 autocomplete
@@ -172,10 +173,12 @@ Ventura
 videoconferences
 VSCodium
 walkable
+walkthrough
 writeable
 WSL
 XCode
 YAML
 Zakeri
 zebrafish
+ZenHub
 Zenodo

--- a/instructor_notes/openscpca/04_code-review-walkthrough.md
+++ b/instructor_notes/openscpca/04_code-review-walkthrough.md
@@ -10,17 +10,22 @@
 
 ## Activity/Demo
 
+Instructor will walk/talk through an example pull request in the OpenScPCA project.
+The participants are not expected to do anything but follow along (though they might open some of the links in their own browser to read more easily).
+
 1. Start with the showing the following open issue: https://github.com/AlexsLemonade/OpenScPCA-analysis/issues/374
-    - Note the link back to the discussion topic. (Do we want to show the form for submitting a new issue and/or discussion topic here?)
+    - Note the link back to the discussion topic. (revisit the form for submitting a new issue and/or discussion topic here, as review)
+    - Show that there are other issues linked to this discussion/module, with each representing a chunk of work
     - Note links to other issues (we probably want to do this from a browser _without_ ZenHub)
-    - Note assignees as a thing?
+    - Note assignees
 
 2. Show the Pull Request template:
     - Open a new tab to *your* fork of the OpenScPCA-analysis repository
-    - Have a branch with some changes ready to go, and navigate to that branch
-    - Start to create a PR from that branch back to origin/main
+    - Have a branch with some changes ready to go, and navigate to that branch (this should be ready from the previous activity)
+    - Start to create a PR from that branch back to upstream/main
     - Show the pull request template: note that this one is _not_ a form, but a Markdown file that you will need to edit
-    - Suggest copying the template to a new file to work on it, and then pasting results in.
+    - Suggest copying the template to a new file to work on it, and then pasting results in
+    - Point out checkboxes at the bottom: these can be checked off after filing the PR!
 
 3. Navigate, in a new tab, to the following completed PR: https://github.com/AlexsLemonade/OpenScPCA-analysis/pull/391
     - Show how this is an excellent example of a PR, with links to relevant issues, a clear description of the changes, and instructions for the reviewer
@@ -28,9 +33,11 @@
 
 4.  Go over the first review, noting that the first review is generally going to be a high-level review
     - How much code is there here, is the organization good?
-    - Are the changes clear
+    - Are the changes clear?
     - What questions did the submitter have?
-    - There may also be line-level comments, show how those look, but note that they may get more detailed later
+    - There may also be line-level comments; show how those look, but note that they may get more detailed later.
 
 5.  A brief scan through the remaining comments on the PR
     - Note that review comments are likely to get more detailed (though easier) as the review process goes on.
+    - Discuss different kinds of comments (line, file, overall)
+    - Point out button to resolve a comment (and comment about what that means)

--- a/instructor_notes/openscpca/04_code-review-walkthrough.md
+++ b/instructor_notes/openscpca/04_code-review-walkthrough.md
@@ -1,0 +1,32 @@
+
+# Instructor Notes: Code Review Walkthrough
+
+
+## Learning goals
+
+- Get familiar with a typical code review process in the OpenScPCA project
+- Understand the components of a Pull Request (PR) in the OpenScPCA project
+- See what a typical first review might look like
+
+## Activity
+
+1. Start with the showing the following open issue: https://github.com/AlexsLemonade/OpenScPCA-analysis/issues/374
+   - Note the link back to the discussion topic. (Do we want to show the form for submitting a new issue and/or discussion topic here?)
+   - Note links to other issues (we probably want to do this from a browser _without_ zenhub)
+   - Note assignees as a thing?
+
+2. Open a new tab to your fork of the OpenScPCA-analysis repository:
+   - Have a branch with some changes ready to go, and navigate to that branch
+   - Start to create a PR from that branch back to origin/main
+   - Show the pull request template: note that this one is _not_ a form, but a markdown file that you will need to edit
+   - Suggest copying the template to a new file to work on it, and then pasting results in.
+
+3. Navigate, in a new tab, to the following completed PR: https://github.com/AlexsLemonade/OpenScPCA-analysis/pull/391
+   - Show how this is an excellent example of a PR, with links to relevant issues, a clear description of the changes, and instructions for the reviewer
+     - Note the link to the results directory
+   - Go over the first review, noting that the first review is generally going to be a high-level review
+     - How much code is there here, is the organization good?
+     - Are the changes clear
+     - What questions did the submitter have?
+     - There may also be line-level comments, show how those look, but note that they may get more detailed later
+   - A brief scan through the remaining comments, noting that they are likely to get more detailed (though easier) as the review process goes on.

--- a/instructor_notes/openscpca/04_code-review-walkthrough.md
+++ b/instructor_notes/openscpca/04_code-review-walkthrough.md
@@ -12,7 +12,7 @@
 
 1. Start with the showing the following open issue: https://github.com/AlexsLemonade/OpenScPCA-analysis/issues/374
     - Note the link back to the discussion topic. (Do we want to show the form for submitting a new issue and/or discussion topic here?)
-    - Note links to other issues (we probably want to do this from a browser _without_ zenhub)
+    - Note links to other issues (we probably want to do this from a browser _without_ ZenHub)
     - Note assignees as a thing?
 
 2. Show the Pull Request template:

--- a/instructor_notes/openscpca/04_code-review-walkthrough.md
+++ b/instructor_notes/openscpca/04_code-review-walkthrough.md
@@ -6,27 +6,31 @@
 
 - Get familiar with a typical code review process in the OpenScPCA project
 - Understand the components of a Pull Request (PR) in the OpenScPCA project
-- See what a typical first review might look like
+- See what a typical review process might look like
 
-## Activity
+## Activity/Demo
 
 1. Start with the showing the following open issue: https://github.com/AlexsLemonade/OpenScPCA-analysis/issues/374
-   - Note the link back to the discussion topic. (Do we want to show the form for submitting a new issue and/or discussion topic here?)
-   - Note links to other issues (we probably want to do this from a browser _without_ zenhub)
-   - Note assignees as a thing?
+    - Note the link back to the discussion topic. (Do we want to show the form for submitting a new issue and/or discussion topic here?)
+    - Note links to other issues (we probably want to do this from a browser _without_ zenhub)
+    - Note assignees as a thing?
 
-2. Open a new tab to your fork of the OpenScPCA-analysis repository:
-   - Have a branch with some changes ready to go, and navigate to that branch
-   - Start to create a PR from that branch back to origin/main
-   - Show the pull request template: note that this one is _not_ a form, but a markdown file that you will need to edit
-   - Suggest copying the template to a new file to work on it, and then pasting results in.
+2. Show the Pull Request template:
+    - Open a new tab to *your* fork of the OpenScPCA-analysis repository
+    - Have a branch with some changes ready to go, and navigate to that branch
+    - Start to create a PR from that branch back to origin/main
+    - Show the pull request template: note that this one is _not_ a form, but a Markdown file that you will need to edit
+    - Suggest copying the template to a new file to work on it, and then pasting results in.
 
 3. Navigate, in a new tab, to the following completed PR: https://github.com/AlexsLemonade/OpenScPCA-analysis/pull/391
-   - Show how this is an excellent example of a PR, with links to relevant issues, a clear description of the changes, and instructions for the reviewer
-     - Note the link to the results directory
-   - Go over the first review, noting that the first review is generally going to be a high-level review
-     - How much code is there here, is the organization good?
-     - Are the changes clear
-     - What questions did the submitter have?
-     - There may also be line-level comments, show how those look, but note that they may get more detailed later
-   - A brief scan through the remaining comments, noting that they are likely to get more detailed (though easier) as the review process goes on.
+    - Show how this is an excellent example of a PR, with links to relevant issues, a clear description of the changes, and instructions for the reviewer
+    - Note the link to the results directory
+
+4.  Go over the first review, noting that the first review is generally going to be a high-level review
+    - How much code is there here, is the organization good?
+    - Are the changes clear
+    - What questions did the submitter have?
+    - There may also be line-level comments, show how those look, but note that they may get more detailed later
+
+5.  A brief scan through the remaining comments on the PR
+    - Note that review comments are likely to get more detailed (though easier) as the review process goes on.


### PR DESCRIPTION
Closes #154 

Here I am adding some notes for the analysis/review demo. It is pretty brief, consisting mostly of going through at a past PR and pointing out highlights from that review.

There is one additional step for showing the initial PR template in context, as that requires a branch with some change in it, but this should be covered by the contents of the new module from a previous demo. 

Let me know if there are steps that you would like to see more detail about, or if there are components that I missed completely!

