### PR TITLE
Add link to Google Slides view for analytical code review

### DIFF
--- a/docs/workshop-schedule.md
+++ b/docs/workshop-schedule.md
@@ -43,7 +43,7 @@ Topics in the schedule link to the associated Google Slide deck we will present.
 | 11:30 am - 12:30 pm | Developing OpenScPCA analysis modules, Part 1   |
 | 12:30 - 1:30 pm     | _Lunch_                                         |
 | 1:30 - 2:15 pm      | Developing OpenScPCA analysis modules, Part 2   |
-| 2:15 - 2:45 pm      | Analytical code review                          |
+| 2:15 - 2:45 pm      | [Analytical code review](https://docs.google.com/presentation/d/1aqIn8qmn7ijwgVzFd6mtfxBTD6UPEKaLOxOQNyMYUQs/edit?usp=sharing)                          |
 | 2:45 - 3:00 pm      | _Coffee break_                                  |
 | 3:00 - 3:45 pm      | Explore a current OpenScPCA analysis            |
 | 3:45 - 5:00 pm      | Open discussion, Q&A, and OpenScPCA exploration |


### PR DESCRIPTION
Stacked on #166 

Related to #165 

Adding a link to Google Slides for the analytical code review slides