### PR TITLE
Add instructor notes for git CLI on RStudio 

### DIFF
--- a/instructor_notes/11_git-init-server.md
+++ b/instructor_notes/11_git-init-server.md
@@ -1,12 +1,12 @@
 # Instructor Notes: Initializing a git repository on RStudio Server
 
-This document provides instructions for creating a git repository in an existing directory on the Data Lab's RStudio Server, as well as setting up associated git credentials.
+This document provides instructions for setting up git credentials and creating/working with a git repository in an existing directory on the Data Lab's RStudio Server.
 
 ## Learning goals
 
 At the end of this activity, workshop attendees will have:
 
-* Learned about git Personal Access Tokens and credentials
+* Learned about credentials and created a GitHub Personal Access Tokens
 * Performed basic git configuration using git CLI
 * Used basic git CLI commands
 
@@ -90,13 +90,14 @@ For this, instruct participants to create a new corresponding repo on GitHub.com
 
 * Copy/paste the `https` URL (`{REMOTE-URL}`) for use in the following code in terminal:
 ```sh
-# Set the remote repo address
+# set the remote repo address
+# note that this only has to be done once for a newly initialized repo
 git remote add origin {REMOTE-URL}
 
 # push to main
-# The `-u origin main` part is only needed the first time you push to a branch that you have not pushed to before,
+# note that the `-u origin main` part is only needed the first time you push to a branch that you have not pushed to before,
 #  or does not exist on the remote
-# Moving forward in this branch, pushing will go to this URL by default
+# moving forward in this branch, pushing will go to this URL by default
 git push -u origin main
 ```
 
@@ -109,6 +110,7 @@ Explain that after we complete each training notebook, they should run the follo
 git add <specific .Rmd file>
 git add <specific .html file>
 
+# commit and push
 git commit -m "Informative message about notebook being added"
 
 git push
@@ -122,7 +124,7 @@ git switch -c new-feature-branch
 
 # add, commit your work
 
-# the first push requires `-u origin <name of remote branch to create>
+# the first push requires `-u origin <name of remote branch to create>`
 git push -u origin new-feature-branch
 
 # note that you can switch back to any existing branch, e.g. main, with:

--- a/instructor_notes/11_git-init-server.md
+++ b/instructor_notes/11_git-init-server.md
@@ -7,7 +7,7 @@ This document provides instructions for creating a git repository in an existing
 At the end of this activity, workshop attendees will have:
 
 * Learned about git Personal Access Tokens and credentials
-* Learned basic git configuration using R tools
+* Performed basic git configuration using git CLI
 * Used basic git CLI commands
 
 ## Part 1: Set up git credentials

--- a/instructor_notes/11_git-init-server.md
+++ b/instructor_notes/11_git-init-server.md
@@ -117,13 +117,16 @@ git push
 Note that if they wanted to create a new branch and push it to GitHub, they would do:
 
 ```sh
-# create new branch and switch to it
+# create new branch (-c) and switch to it
 git switch -c new-feature-branch
 
 # add, commit your work
 
 # the first push requires `-u origin <name of remote branch to create>
 git push -u origin new-feature-branch
+
+# note that you can switch back to any existing branch, e.g. main, with:
+git switch main
 ```
 
 We can further explain that they can add an additional field to their `.gitconfig` which will automatically create

--- a/instructor_notes/11_git-init-server.md
+++ b/instructor_notes/11_git-init-server.md
@@ -159,6 +159,12 @@ git switch -c new-feature-branch
 # add, commit your work
 
 # the first push requires `-u origin <name of remote branch to create>
-git push -u origin
+git push -u origin new-feature-branch
 ```
 
+We can further explain that they can add an additional field to their `.gitconfig` which will automatically create
+any remote branch with:
+
+```sh
+git config --global init.defaultBranch "main"
+```

--- a/instructor_notes/11_git-init-server.md
+++ b/instructor_notes/11_git-init-server.md
@@ -14,7 +14,7 @@ At the end of this activity, workshop attendees will have:
 
 ### Set up the `~/.gitconfig` file
 
-This can either be done directly in the editor by opening `~/.gitconfig`, or with `usethis` which may be safer for ensuring correct spacing:
+This can either be done using `git` CLI in Terminal, or with the `usethis` package in R.
 
 In the end, the `~/.gitconfig` file should look like this (where the `init` block is optional but recommended):
 
@@ -28,12 +28,25 @@ In the end, the `~/.gitconfig` file should look like this (where the `init` bloc
     defaultBranch = "main"
 ```
 
-The `usethis` code to add this content to `~/.gitconfig` is below.
+#### Set up `~/.gitconfig` via Terminal
+
+```
+git config --global user.email "your_email@example.com"
+git config --global user.name "name"
+git config --global credential.helper "cache --timeout=43200"
+
+# optional but useful
+git config --global init.defaultBranch "main"
+```
+
+#### Set up `~/.gitconfig` via R
+
 If `usethis` is used, instruct participants to view the `~/.gitconfig` file after each step to see how the file has been modified.
 Note that `usethis::use_git_config()` will not modify (or delete!) other fields besides those provided to the function.
 
 ```r
 # Step 1: Create config file with user and email
+# We start with this step on its own because it applies to any system they'll work on
 usethis::use_git_config(
     user.name = "Participant Name",
     user.email = "Participant Email",
@@ -44,6 +57,8 @@ usethis::use_git_config(
 )
 # Step 2: Set up credential helper to be able to temporarily store PAT on the server
 # Note that this could be combined with step 1 as an additional argument
+# We do this step separately because it is more specific to RStudio Server usage and may not apply
+#  to other circumstances beyond this workshop.
 usethis::use_git_config(
     credential.helper = "cache --timeout=43200" # 12 hours
 )
@@ -51,22 +66,39 @@ usethis::use_git_config(
 
 ### Add your Personal Access Token
 
-* Instruct participants to navigate to their GitHub.com account's Developer settings and create a classic token with the `repo` scope that lasts for 7 days.
+> Maintain security during this activity and turn off the instructor's projector (i.e., do not screen share) when tokens are being displayed.
+
+* Instruct participants to navigate to their GitHub.com account's Developer settings (`Settings > Developer Settings > Personal Access Tokens`)
+  * Create a Classic token that lasts for 7 days as follows:
+    * Provide an informative token name
+    * Select scopes: `repo`, `user`, and `gist`
+  * **Before clicking `Generate Token`, make sure the screen share is off.**
   * Once the token is created, copy/paste it and save in a (local) _secure location_.
   Emphasize that if they have a password manager, they should use it!
 * In the R Console in the RStudio Server, use the `gitcreds` package to store this information:
+**Before pasting the token, make sure screen share is off.**
   * Run `gitcreds::gitcreds_set()` and paste the PAT into Console.
-  * Then, run `gitcreds::gitcreds_get()` to ensure a PAT has been set.
-* Explain that they will have to repeat this step every 12 hours to be able to continue communicating with GitHub because of how we set up caching on RStudio Server and in their `.gitconfig`
+  * Clear the Console so the PAT is no longer visible before resuming screen share.
+* Run `gitcreds::gitcreds_get()` to ensure a PAT has been set.
+They should see this output if it was successful:
+
+    ```r
+    > gitcreds::gitcreds_get()
+    <gitcreds>
+    protocol: https
+    host    : github.com
+    username: PersonalAccessToken
+    password: <-- hidden -->
+    ```
+* Explain that they will have to repeat this step every 12 hours to be able to continue communicating with GitHub because of how we set up caching on RStudio Server.
 
 ## Part 2: Create a git repository
 
-* In the Terminal, navigate to the `training-modules` workshop directory, which participants are going to turn into a git repository and create a repository:
+* In the Terminal, navigate to the `training-modules` workshop directory and create a repository:
 
 ```sh
-# Navigate to the training modules directory
+# Navigate to the training-modules directory
 cd ~/training-modules
-```
 
 # Create a git repository
 git init
@@ -92,13 +124,15 @@ git commit -m "First commit for RNA-seq workshop materials repo"
 For this, instruct participants to create a new repo on GitHub.com
     * _Do not_ initialize the repository with any files (no `README`, `.gitignore`, or `LICENSE`)
 
-* Copy/paste the `https` URL (`{REMOTE-URL}`) and use for the following code back in the terminal:
+* Copy/paste the `https` URL (`{REMOTE-URL}`) and use for the following code back in R:
 ```sh
 # Set the remote repo address
 git remote add origin {REMOTE-URL}
 
-# push to main!
-# now, pushing will go to this URL by default
+# push to main
+# The `-u origin main` part is only needed the first time you push to a branch that you have not pushed to before,
+#  or does not exist on the remote
+# Moving forward in this branch, pushing will go to this URL by default
 git push -u origin main
 ```
 
@@ -115,3 +149,16 @@ git commit -m "Informative message about notebook being added"
 
 git push
 ```
+
+Note that if they wanted to create a new branch and push it to GitHub, they would do:
+
+```sh
+# create new branch
+git switch -c new-feature-branch
+
+# add, commit your work
+
+# the first push requires `-u origin <name of remote branch to create>
+git push -u origin
+```
+

--- a/instructor_notes/11_git-init-server.md
+++ b/instructor_notes/11_git-init-server.md
@@ -71,7 +71,8 @@ usethis::use_git_config(
 * Instruct participants to navigate to their GitHub.com account's Developer settings (`Settings > Developer Settings > Personal Access Tokens`)
   * Create a Classic token that lasts for 7 days as follows:
     * Provide an informative token name
-    * Select scopes: `repo`, `user`, and `gist`
+    * Select `repo` scope for this token
+    * Take this moment to discuss scopes in general (in particular `user`, `gist`, and `notifications`): https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/scopes-for-oauth-apps
   * **Before clicking `Generate Token`, make sure the screen share is off.**
   * Once the token is created, copy/paste it and save in a (local) _secure location_.
   Emphasize that if they have a password manager, they should use it!

--- a/instructor_notes/11_git-init-server.md
+++ b/instructor_notes/11_git-init-server.md
@@ -14,7 +14,7 @@ At the end of this activity, workshop attendees will have:
 
 ### Set up the `~/.gitconfig` file
 
-Use git CLI to set up the config file, which should should look like this (where the `init` block is optional but recommended) once it's created:
+Use git CLI to set up the `~/.gitconfig` file, which should should look like this (where the `init` block is optional but recommended) once it's created:
 
 ```yml
 [user]
@@ -39,6 +39,7 @@ git config --global credential.helper "cache --timeout=43200"
 # Optional but useful: name the default branch `main`
 git config --global init.defaultBranch "main"
 ```
+
 
 ### Create a Personal Access Token (PAT)
 

--- a/instructor_notes/11_git-init-server.md
+++ b/instructor_notes/11_git-init-server.md
@@ -1,0 +1,116 @@
+# Instructor Notes: Initializing a git repository on RStudio Server
+
+This document provides instructions for creating a git repository in an existing directory on the CCDL's RStudio Server, as well as setting up associated git credentials.
+
+## Learning goals
+
+At the end of this activity, workshop attendees will have:
+
+* Learned about git Personal Access Tokens and credentials
+* Learned basic git configuration using R tools
+* Used basic git CLI commands
+
+## Part 1: Set up git credentials
+
+### Set up the `~/.gitconfig` file
+
+This can either be done directly in the editor by opening `~/.gitconfig`, or with `usethis` which may be safer for ensuring correct spacing:
+
+In the end, the `~/.gitconfig` file should look like this (where the `init` block is optional but recommended):
+
+```yml
+[user]
+    email = Participant Email
+    name = Participant Name
+[credential]
+    helper = cache --timeout=43200
+[init]
+    defaultBranch = "main"
+```
+
+The `usethis` code to add this content to `~/.gitconfig` is below.
+If `usethis` is used, instruct participants to view the `~/.gitconfig` file after each step to see how the file has been modified.
+Note that `usethis::use_git_config()` will not modify (or delete!) other fields besides those provided to the function.
+
+```r
+# Step 1: Create config file with user and email
+usethis::use_git_config(
+    user.name = "Participant Name",
+    user.email = "Participant Email",
+    # Optional setting to ensure the config is global for the user
+    scope = "user",
+    # Optional setting to use `main` as default branch when creating a new repo
+    init.defaultBranch = "main"
+)
+# Step 2: Set up credential helper to be able to temporarily store PAT on the server
+# Note that this could be combined with step 1 as an additional argument
+usethis::use_git_config(
+    credential.helper = "cache --timeout=43200" # 12 hours
+)
+```
+
+### Add your Personal Access Token
+
+* Instruct participants to navigate to their GitHub.com account's Developer settings and create a classic token with the `repo` scope that lasts for 7 days.
+  * Once the token is created, copy/paste it and save in a (local) _secure location_.
+  Emphasize that if they have a password manager, they should use it!
+* In the R Console in the RStudio Server, use the `gitcreds` package to store this information:
+  * Run `gitcreds::gitcreds_set()` and paste the PAT into Console.
+  * Then, run `gitcreds::gitcreds_get()` to ensure a PAT has been set.
+* Explain that they will have to repeat this step every 12 hours to be able to continue communicating with GitHub because of how we set up caching on RStudio Server.
+
+## Part 2: Create a git repository
+
+* In the Terminal, navigate to the `RNA-Seq` workshop directory, which participants are going to turn into a git repository and create a repository:
+
+```sh
+# Navigate to the RNA-seq directory
+cd ~/training-modules/RNA-seq
+
+# Create a git repository
+git init
+```
+
+* Before adding and committing, take a moment to look at the `.gitignore` file present in this directory to see what we expect to be added vs ignored.
+
+* Run the following code to add, commit, and push the new repo to GitHub:
+```sh
+# Add all (non-ignored) files to the directory
+# Explain that we generally like to add files one at a time, but this strategy is appropriate for
+#  the context of initializing a repo, especially given the presence of the .gitignore file!
+git add .
+
+# Throw in a git status for good measure (run as often as desired while using git!)
+git status
+
+# Make a commit
+git commit -m "First commit for RNA-seq workshop materials repo"
+```
+
+* Next, we need a corresponding remote repository to push to.
+For this, instruct participants to create a new repo on GitHub.com
+    * _Do not_ initialize the repository with any files (no `README`, `.gitignore`, or `LICENSE`)
+
+* Copy/paste the `https` URL (`{REMOTE-URL}`) and use for the following code back in R:
+```sh
+# Set the remote repo address
+git remote add origin {REMOTE-URL}
+
+# push to main!
+# now, pushing will go to this URL by default
+git push -u origin main
+```
+
+## Next steps
+
+Explin that after we complete each training notebook, they should run the following to sync their local repo with GitHub:
+
+```sh
+# add files one at a time
+git add <specific .Rmd file>
+git add <specific .html file>
+
+git commit -m "Informative message about notebook being added"
+
+git push
+```

--- a/instructor_notes/11_git-init-server.md
+++ b/instructor_notes/11_git-init-server.md
@@ -57,15 +57,16 @@ usethis::use_git_config(
 * In the R Console in the RStudio Server, use the `gitcreds` package to store this information:
   * Run `gitcreds::gitcreds_set()` and paste the PAT into Console.
   * Then, run `gitcreds::gitcreds_get()` to ensure a PAT has been set.
-* Explain that they will have to repeat this step every 12 hours to be able to continue communicating with GitHub because of how we set up caching on RStudio Server.
+* Explain that they will have to repeat this step every 12 hours to be able to continue communicating with GitHub because of how we set up caching on RStudio Server and in their `.gitconfig`
 
 ## Part 2: Create a git repository
 
-* In the Terminal, navigate to the `RNA-Seq` workshop directory, which participants are going to turn into a git repository and create a repository:
+* In the Terminal, navigate to the `training-modules` workshop directory, which participants are going to turn into a git repository and create a repository:
 
 ```sh
-# Navigate to the RNA-seq directory
-cd ~/training-modules/RNA-seq
+# Navigate to the training modules directory
+cd ~/training-modules
+```
 
 # Create a git repository
 git init
@@ -91,7 +92,7 @@ git commit -m "First commit for RNA-seq workshop materials repo"
 For this, instruct participants to create a new repo on GitHub.com
     * _Do not_ initialize the repository with any files (no `README`, `.gitignore`, or `LICENSE`)
 
-* Copy/paste the `https` URL (`{REMOTE-URL}`) and use for the following code back in R:
+* Copy/paste the `https` URL (`{REMOTE-URL}`) and use for the following code back in the terminal:
 ```sh
 # Set the remote repo address
 git remote add origin {REMOTE-URL}

--- a/instructor_notes/11_git-init-server.md
+++ b/instructor_notes/11_git-init-server.md
@@ -26,7 +26,7 @@ Use git CLI to set up the `~/.gitconfig` file, which should should look like thi
     defaultBranch = "main"
 ```
 
-To create the file, run these lines in terminal:
+To create the file, run these lines in terminal, each commented set at a time to explain clearly what each is doing:
 
 ```sh
 # Add email and username
@@ -58,7 +58,7 @@ git config --global init.defaultBranch "main"
 
 ## Part 2: Create a git repository
 
-* In the Terminal, navigate to the `training-modules` workshop directory and create a repository:
+* In the Terminal, navigate to the `~/training-modules` workshop directory and create a repository:
 
 ```sh
 # Navigate to the training-modules directory
@@ -85,10 +85,10 @@ git commit -m "First commit for RNA-seq workshop materials repo"
 ```
 
 * Next, we need a corresponding remote repository to push to.
-For this, instruct participants to create a new repo on GitHub.com
+For this, instruct participants to create a new corresponding repo on GitHub.com
     * _Do not_ initialize the repository with any files (no `README`, `.gitignore`, or `LICENSE`)
 
-* Copy/paste the `https` URL (`{REMOTE-URL}`) and use for the following code back in terminal:
+* Copy/paste the `https` URL (`{REMOTE-URL}`) for use in the following code in terminal:
 ```sh
 # Set the remote repo address
 git remote add origin {REMOTE-URL}

--- a/instructor_notes/11_git-init-server.md
+++ b/instructor_notes/11_git-init-server.md
@@ -1,6 +1,6 @@
 # Instructor Notes: Initializing a git repository on RStudio Server
 
-This document provides instructions for creating a git repository in an existing directory on the CCDL's RStudio Server, as well as setting up associated git credentials.
+This document provides instructions for creating a git repository in an existing directory on the Data Lab's RStudio Server, as well as setting up associated git credentials.
 
 ## Learning goals
 
@@ -103,7 +103,7 @@ git push -u origin main
 
 ## Next steps
 
-Explin that after we complete each training notebook, they should run the following to sync their local repo with GitHub:
+Explain that after we complete each training notebook, they should run the following to sync their local repo with GitHub:
 
 ```sh
 # add files one at a time

--- a/instructor_notes/11_git-init-server.md
+++ b/instructor_notes/11_git-init-server.md
@@ -14,9 +14,7 @@ At the end of this activity, workshop attendees will have:
 
 ### Set up the `~/.gitconfig` file
 
-This can either be done using `git` CLI in Terminal, or with the `usethis` package in R.
-
-In the end, the `~/.gitconfig` file should look like this (where the `init` block is optional but recommended):
+Use git CLI to set up the config file, which should should look like this (where the `init` block is optional but recommended) once it's created:
 
 ```yml
 [user]
@@ -28,70 +26,34 @@ In the end, the `~/.gitconfig` file should look like this (where the `init` bloc
     defaultBranch = "main"
 ```
 
-#### Set up `~/.gitconfig` via Terminal
+To create the file, run these lines in terminal:
 
-```
+```sh
+# Add email and username
 git config --global user.email "your_email@example.com"
 git config --global user.name "name"
+
+# Cache credentials for 12 hours
 git config --global credential.helper "cache --timeout=43200"
 
-# optional but useful
+# Optional but useful: name the default branch `main`
 git config --global init.defaultBranch "main"
 ```
 
-#### Set up `~/.gitconfig` via R
-
-If `usethis` is used, instruct participants to view the `~/.gitconfig` file after each step to see how the file has been modified.
-Note that `usethis::use_git_config()` will not modify (or delete!) other fields besides those provided to the function.
-
-```r
-# Step 1: Create config file with user and email
-# We start with this step on its own because it applies to any system they'll work on
-usethis::use_git_config(
-    user.name = "Participant Name",
-    user.email = "Participant Email",
-    # Optional setting to ensure the config is global for the user
-    scope = "user",
-    # Optional setting to use `main` as default branch when creating a new repo
-    init.defaultBranch = "main"
-)
-# Step 2: Set up credential helper to be able to temporarily store PAT on the server
-# Note that this could be combined with step 1 as an additional argument
-# We do this step separately because it is more specific to RStudio Server usage and may not apply
-#  to other circumstances beyond this workshop.
-usethis::use_git_config(
-    credential.helper = "cache --timeout=43200" # 12 hours
-)
-```
-
-### Add your Personal Access Token
+### Create a Personal Access Token (PAT)
 
 > Maintain security during this activity and turn off the instructor's projector (i.e., do not screen share) when tokens are being displayed.
 
 * Instruct participants to navigate to their GitHub.com account's Developer settings (`Settings > Developer Settings > Personal Access Tokens`)
-  * Create a Classic token that lasts for 7 days as follows:
-    * Provide an informative token name
-    * Select `repo` scope for this token
-    * Take this moment to discuss scopes in general (in particular `user`, `gist`, and `notifications`): https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/scopes-for-oauth-apps
-  * **Before clicking `Generate Token`, make sure the screen share is off.**
-  * Once the token is created, copy/paste it and save in a (local) _secure location_.
+* Create a Classic PAT that lasts for 7 days as follows:
+  * Provide an informative PAT name
+  * Select `repo` scope for this token
+  * Take this moment to discuss scopes in general (in particular `user`, `gist`, and `notifications`): https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/scopes-for-oauth-apps
+* **Before clicking `Generate Token`, make sure the screen share is off.**
+  * Once the PAT is created, copy/paste it and save in a (local) _secure location_.
   Emphasize that if they have a password manager, they should use it!
-* In the R Console in the RStudio Server, use the `gitcreds` package to store this information:
-**Before pasting the token, make sure screen share is off.**
-  * Run `gitcreds::gitcreds_set()` and paste the PAT into Console.
-  * Clear the Console so the PAT is no longer visible before resuming screen share.
-* Run `gitcreds::gitcreds_get()` to ensure a PAT has been set.
-They should see this output if it was successful:
-
-    ```r
-    > gitcreds::gitcreds_get()
-    <gitcreds>
-    protocol: https
-    host    : github.com
-    username: PersonalAccessToken
-    password: <-- hidden -->
-    ```
-* Explain that they will have to repeat this step every 12 hours to be able to continue communicating with GitHub because of how we set up caching on RStudio Server.
+* Explain that participants will use this PAT instead of their password when git prompts them to enter credentials
+  * They will be prompted every 12 hours, per the cache we set up in the last step
 
 ## Part 2: Create a git repository
 
@@ -167,5 +129,5 @@ We can further explain that they can add an additional field to their `.gitconfi
 any remote branch with:
 
 ```sh
-git config --global init.defaultBranch "main"
+git config --global push.autoSetupRemote "true"
 ```

--- a/instructor_notes/11_git-init-server.md
+++ b/instructor_notes/11_git-init-server.md
@@ -117,7 +117,7 @@ git push
 Note that if they wanted to create a new branch and push it to GitHub, they would do:
 
 ```sh
-# create new branch
+# create new branch and switch to it
 git switch -c new-feature-branch
 
 # add, commit your work

--- a/instructor_notes/11_git-init-server.md
+++ b/instructor_notes/11_git-init-server.md
@@ -87,7 +87,7 @@ git commit -m "First commit for RNA-seq workshop materials repo"
 For this, instruct participants to create a new repo on GitHub.com
     * _Do not_ initialize the repository with any files (no `README`, `.gitignore`, or `LICENSE`)
 
-* Copy/paste the `https` URL (`{REMOTE-URL}`) and use for the following code back in R:
+* Copy/paste the `https` URL (`{REMOTE-URL}`) and use for the following code back in terminal:
 ```sh
 # Set the remote repo address
 git remote add origin {REMOTE-URL}

--- a/instructor_notes/README.md
+++ b/instructor_notes/README.md
@@ -3,7 +3,7 @@ This directory contains teaching notes and related materials for instructor refe
 * `00_instructor-setup.md` contains an instructor setup for teaching workshop workshop_materials.
 * All other numbered markdown files contain instructor notes for the given live demonstration.
 Files are numbered the same order as their corresponding [slides](../workshop_materials/slides/).
-  * The instructor notes entitled `11_git-init-server.md` are used to introduce working with git on the CCDL's RStudio Server and are only used in certain versions of the RRP workshop.
+  * The instructor notes entitled `11_git-init-server.md` are used to introduce working with git on the Data Lab's RStudio Server and are only used in certain versions of the Reproducible Research Practices workshop.
 * Bash scripts `<no>variables_download-fastq.sh` contain solution scripts for the ["Shell Scripting" live demonstration](06_shell-scripting.md).
 * The directory `fastq_subset` contains small versions of FASTQ files, as well as the script to create them, which can be used during the "Shell Scripting" live demonstration in the event of poor internet quality.
 

--- a/instructor_notes/README.md
+++ b/instructor_notes/README.md
@@ -3,6 +3,7 @@ This directory contains teaching notes and related materials for instructor refe
 * `00_instructor-setup.md` contains an instructor setup for teaching workshop workshop_materials.
 * All other numbered markdown files contain instructor notes for the given live demonstration.
 Files are numbered the same order as their corresponding [slides](../workshop_materials/slides/).
+  * The instructor notes entitled `11_git-init-server.md` are used to introduce working with git on the CCDL's RStudio Server and are only used in certain versions of the RRP workshop.
 * Bash scripts `<no>variables_download-fastq.sh` contain solution scripts for the ["Shell Scripting" live demonstration](06_shell-scripting.md).
 * The directory `fastq_subset` contains small versions of FASTQ files, as well as the script to create them, which can be used during the "Shell Scripting" live demonstration in the event of poor internet quality.
 


### PR DESCRIPTION
Towards #179 

This PR adds instructor notes for the new git activity, including setting up config, adding a token, init'ing a repo, and add/push/commit. For the PAT section, I also included instructions for using `usethis`to write the `~/.gitconfig` file as an option. Let me know if anything is missed or should be expanded on!

One question I have is whether I've placed this file in the right location and/or it's been reasonably documented. I wonder if we actually want to save this in something like `instructor_notes/supplemental_activities` so it's clearly separate from "regular" RRP notes?