### PR TITLE
Add draft schedule for YI RRP

### DIFF
--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -161,6 +161,7 @@ softwares
 SSO
 subfolder
 symlinks
+TBD
 TextEdit
 th
 tidyverse

--- a/docs/workshop-schedule.md
+++ b/docs/workshop-schedule.md
@@ -3,49 +3,40 @@ title: Workshop Schedule
 nav_title: Schedule
 ---
 
-The schedule below is a tentative schedule for the May 14-15th workshop.
-Times are subject to change, but the overall content should stay the same.
+The schedule below is a tentative schedule for the 2024 October "Reproducible Research Practices" workshop.
+This schedule is subject to minor changes but the overall content will remain the same.
+
+The workshop will takes place on October 23-24, 2024 at Northwestern Mutual Headquarters in Milwaukee, WI (720 E Wisconsin Ave).
+We will meet in Room 2E on the 2nd floor.
 
 Topics in the schedule link to the associated Google Slide deck we will present.
 
-## Day 1: Reproducible Research Practices, 9 am - 5 pm
+## Day 1: Wednesday October 23rd, 2:30 - 5:00 PM
 
-| Time                | Topic                                                                                                                                                         |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 8:30 am             | _Participants arrive, have breakfast, and check in_                                                                                                           |
-| 9:00 - 10:15 am     | [Welcome and introductions](https://docs.google.com/presentation/d/1HPUXRrQsD68QyEQMbexOfM9Roz6VqUeIg_gCs7FSqVg/edit?usp=sharing)                             |
-|                     | [Why does reproducibility matter?](https://docs.google.com/presentation/d/1qfulAR4jD0KS7NfrLHpwT6SWl-7APBmqNnAwGpXX5oo/edit?usp=sharing)                      |
-| 10:15 - 10:45 am    | [Project organization](https://docs.google.com/presentation/d/1ncqxXlC0-PGEK-yE7S-nDYnMPhrOUPbI95EJy283wCs/edit?usp=sharing)                                  |
-| 10:45 - 11:00 am    | _Coffee break_                                                                                                                                                |
-| 11:00 - 11:30 am    | [Strategies for data sharing](https://docs.google.com/presentation/d/10NEkqHkAw9KBAbkNV-vtPwLFc9ZHksHEcCFty32efiE/edit?usp=sharing)                           |
-| 11:30 am - 12:00 pm | [Introduction to UNIX and the command line](https://docs.google.com/presentation/d/1WPXkItJZEUXMY20cLrdMXHiBC2PyunR14RUSDg4nfIc/edit?usp=sharing)             |
-|                     | [_Resource_: UNIX Reference](resources/unix_reference.html)                                                                                                   |
-|                     | [_Resource_: UNIX Cheatsheet (pdf)](resources/unix_quick_reference.pdf)                                                                                       |
-| 12:00 - 12:30 pm    | [Introduction to Git; Forking and cloning a repository](https://docs.google.com/presentation/d/1eiGZA4PYBKJx5HDCo3UDOAB7q415gg96TehxilCHwlA/edit?usp=sharing) |
-| 12:30 - 1:30 pm     | _Lunch_                                                                                                                                                       |
-| 1:30 - 2:15 pm      | [Shell scripting](https://docs.google.com/presentation/d/1SDUyYVNgvDDRodVqmDQPVQ5wnjQesWfBTg0EAcdbcSo/edit?usp=sharing)                                       |
-| 2:15 - 2:45 pm      | [The Git stage/commit/push workflow](https://docs.google.com/presentation/d/1_YckNhAkp_82PKR6PGS5SdaKDgoueYVTXaPi5pQV9ik/edit?usp=sharing)                    |
-| 2:45 - 3:00 pm      | _Coffee break_                                                                                                                                                |
-| 3:00 - 3:45 pm      | [Organizing code in scripts and notebooks](https://docs.google.com/presentation/d/1AJr6uQhwLnZfis1wNc_e2XY4XSMEuVscIfAsVgnM5Bk/edit?usp=sharing)              |
-| 3:45 - 4:15 pm      | [Managing packages and environments](https://docs.google.com/presentation/d/1GCbu2F6LeEPOu5DzDsTgwu1__9YDVydvPo911fBG1i0/edit?usp=sharing)                    |
-| 4:15 - 4:45 pm      | [Working with branches in Git](https://docs.google.com/presentation/d/1s7BSHgTSDuXIzI1ROS-JSneB6NXfQVWOec6lhc8eIWA/edit?usp=sharing)                          |
-| 4:45 pm             | _Adjourn_                                                                                                                                                     |
-| 5:45 pm             | _Optional dinner_ at [LeBus East Falls](https://www.lebuseastfalls.com/)                                                                                      |
+| Time           | Topic                                                                                                                                                         |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2:30 - 3:15 PM | [Welcome and introductions](https://docs.google.com/presentation/d/1HPUXRrQsD68QyEQMbexOfM9Roz6VqUeIg_gCs7FSqVg/edit?usp=sharing)                             |
+|                | [Why does reproducibility matter?](https://docs.google.com/presentation/d/1qfulAR4jD0KS7NfrLHpwT6SWl-7APBmqNnAwGpXX5oo/edit?usp=sharing)                      |
+| 3:15 - 3:45 PM | [Project organization](https://docs.google.com/presentation/d/1ncqxXlC0-PGEK-yE7S-nDYnMPhrOUPbI95EJy283wCs/edit?usp=sharing)                                  |
+| 3:45 - 4:15 PM | [Introduction to UNIX and the command line](https://docs.google.com/presentation/d/1WPXkItJZEUXMY20cLrdMXHiBC2PyunR14RUSDg4nfIc/edit?usp=sharing)             |
+|                | [_Resource_: UNIX Reference](resources/unix_reference.html)                                                                                                   |
+|                | [_Resource_: UNIX Cheatsheet (pdf)](resources/unix_quick_reference.pdf)                                                                                       |
+| 4:15 - 4:30 PM | _Break_                                                                                                                                                       |
+| 4:30 - 5:00 PM | [Introduction to Git; Forking and cloning a repository](https://docs.google.com/presentation/d/1eiGZA4PYBKJx5HDCo3UDOAB7q415gg96TehxilCHwlA/edit?usp=sharing) |
+| 5:00 - 5:30 PM | [Shell scripting, part 1](https://docs.google.com/presentation/d/1SDUyYVNgvDDRodVqmDQPVQ5wnjQesWfBTg0EAcdbcSo/edit?usp=sharing)                               |
+| 5:30 PM        | _Adjourn_                                                                                                                                                     |
+| 6:30 PM        | Optional dinner at TBD                                                                                                                                        |
 
-## Day 2: Introduction to OpenScPCA, 9 am - 5 pm
+## Day 2: Thursday October 24th, 9:00 AM - 2:00 PM
 
-| Time                | Topic                                                                                                                             |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| 8:45 am             | _Participants arrive and have breakfast_                                                                                          |
-| 9:00 - 10:00 am     | [Introduction to OpenScPCA](https://docs.google.com/presentation/d/1jC73Or5tCLKtsx9tl9Z8xpYVmKWb1bkXzA3_BJIA-zU/edit?usp=sharing) |
-| 10:00 - 11:15 am    | [OpenScPCA Setup](https://docs.google.com/presentation/d/1kHhz9M3wIUYp6eRqnfU8xTETeTBdDF6TxXx9jBVScAo/edit?usp=sharing)           |
-| 11:15 - 11:30 am    | _Coffee break_                                                                                                                    |
-| 11:30 am - 12:30 pm | Developing OpenScPCA analysis modules, Part 1                                                                                     |
-| 12:30 - 1:30 pm     | _Lunch_                                                                                                                           |
-| 1:30 - 2:15 pm      | Developing OpenScPCA analysis modules, Part 2                                                                                     |
-|                     | [Using conda](https://docs.google.com/presentation/d/1RsDIR2wtfIkdwg6FDJghlZl9qrwuICmupMrDNTKOAjw/edit?usp=sharing)               |
-| 2:15 - 2:45 pm      | [Analytical code review](https://docs.google.com/presentation/d/1aqIn8qmn7ijwgVzFd6mtfxBTD6UPEKaLOxOQNyMYUQs/edit?usp=sharing)    |
-| 2:45 - 3:00 pm      | _Coffee break_                                                                                                                    |
-| 3:00 - 3:45 pm      | Explore a current OpenScPCA analysis                                                                                              |
-| 3:45 - 5:00 pm      | Open discussion, Q&A, and OpenScPCA exploration                                                                                   |
-| 5:00 pm             | _Adjourn_                                                                                                                         |
+| Time             | Topic                                                                                                                                            |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 9:00 - 9:45 AM   | Shell scripting, part 2                                                                                                                          |
+| 9:45 - 10:15 AM  | [The Git stage/commit/push workflow](https://docs.google.com/presentation/d/1_YckNhAkp_82PKR6PGS5SdaKDgoueYVTXaPi5pQV9ik/edit?usp=sharing)       |
+| 10:15 - 10:30 AM | _Coffee break_                                                                                                                                   |
+| 10:30 - 11:15 AM | [Organizing code in scripts and notebooks](https://docs.google.com/presentation/d/1AJr6uQhwLnZfis1wNc_e2XY4XSMEuVscIfAsVgnM5Bk/edit?usp=sharing) |
+| 11:15 - 12:00 PM | [Managing packages and environments](https://docs.google.com/presentation/d/1GCbu2F6LeEPOu5DzDsTgwu1__9YDVydvPo911fBG1i0/edit?usp=sharing)       |
+| 12:00 - 1:00 PM  | _Lunch_                                                                                                                                          |
+| 1:00  - 1:30 PM  | [Working with branches in Git](https://docs.google.com/presentation/d/1s7BSHgTSDuXIzI1ROS-JSneB6NXfQVWOec6lhc8eIWA/edit?usp=sharing)              |
+| 1:30 - 2:00 PM   | Q/A and/or consultation time                                                                                                                |
+| 2:00 PM          | _Adjourn_                                                                                                                                        |                                                                                                                                              |

--- a/docs/workshop-schedule.md
+++ b/docs/workshop-schedule.md
@@ -6,12 +6,12 @@ nav_title: Schedule
 The schedule below is a tentative schedule for the 2024 October "Reproducible Research Practices" workshop.
 This schedule is subject to minor changes but the overall content will remain the same.
 
-The workshop will takes place on October 23-24, 2024 at Northwestern Mutual Headquarters in Milwaukee, WI (720 E Wisconsin Ave).
+The workshop will takes place on October 23-24, 2024 at Northwestern Mutual Headquarters in Milwaukee, WI (805 E Mason Ave).
 We will meet in Room 2E on the 2nd floor.
 
 Topics in the schedule link to the associated Google Slide deck we will present.
 
-## Day 1: Wednesday October 23rd, 2:30 - 5:00 PM
+## Day 1: Wednesday October 23rd, 2:30 - 5:30 PM
 
 | Time           | Topic                                                                                                                                                         |
 | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
Closes #185 

This PR adds the draft schedule for October RRP. For context when reviewing, [here is the internal schedule](https://github.com/AlexsLemonade/training-admin/blob/master/internal-schedules/2024-yi-internal-schedule.md).

All moving parts should be here except the Wednesday dinner location. I ended up keeping slide links in for the draft, but please let me know if we want to hide any before the final schedule. 